### PR TITLE
Cargo.toml: Link to repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "The hacker's BLE (bluetooth low energy) browser terminal app"
 license = "BSD-3-Clause"
 authors = ["Dmitriy Kovalenko <dmtr.kovalenko@outlook.com>"]
+repository = "https://github.com/dmtrKovalenko/blendr"
 
 [[bin]]
 name = "blendr"


### PR DESCRIPTION
The lack of this metadatum means that users coming from crates.io need to go through heuristics ("the LICENSE file is there, probably also the rest of the project" or "artifacts are stored there, so the implied GitHub project is probably the project's repo") instead of just clicking a link.